### PR TITLE
Fix okhttp AccessControlException

### DIFF
--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
@@ -14,6 +14,7 @@ import com.imaginarycode.minecraft.redisbungee.events.PubSubMessageEvent;
 import com.imaginarycode.minecraft.redisbungee.util.NameFetcher;
 import com.imaginarycode.minecraft.redisbungee.util.UUIDFetcher;
 import com.imaginarycode.minecraft.redisbungee.util.UUIDTranslator;
+import com.squareup.okhttp.Dispatcher;
 import com.squareup.okhttp.OkHttpClient;
 import lombok.Getter;
 import lombok.NonNull;
@@ -434,6 +435,8 @@ public final class RedisBungee extends Plugin {
                     public Void call() throws Exception {
                         service = Executors.newFixedThreadPool(16);
                         httpClient = new OkHttpClient();
+                        Dispatcher dispatcher = new Dispatcher(service);
+                        httpClient.setDispatcher(dispatcher);
                         NameFetcher.setHttpClient(httpClient);
                         UUIDFetcher.setHttpClient(httpClient);
                         return null;


### PR DESCRIPTION
Hi,

The UUIDFetcher is causing exceptions because it relies on okhttp, which is creating threads : `AccessControlException - Plugin violation: Illegal thread group access`

The lines causing this are [okhttp](https://github.com/square/okhttp/blob/f1a27df8f9a895f6ef7c1e718e09c65726161a26/okhttp/src/main/java/com/squareup/okhttp/internal/Util.java#L262) and [RedisBungee](https://github.com/thechunknetwork/RedisBungee/blob/06c39/src/main/java/com/imaginarycode/minecraft/redisbungee/util/UUIDFetcher.java#L50)

A more complete stacktrace may be found here https://j.ungeek.fr/6c04f, if it helps.


A simple way to fix it might be to create a `Dispatcher` instance using the Bungee's internal `ExecutorService`, but I haven't tested it. It should not break tests either as they don't (a) rely on bungeecord (b) build their own httpClient;